### PR TITLE
Fix: Add .gitattributes and normalize notebook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.ipynb filter=nbstripout
+*.zpln filter=nbstripout
+*.ipynb diff=ipynb

--- a/notebooks/Example_Semistable_Model.ipynb
+++ b/notebooks/Example_Semistable_Model.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "21327c50-efd6-42df-8637-7293296736f1",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Computing Semistable Models of Plane Curves\n",
@@ -14,8 +14,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "9a37a673-d6eb-441a-8c9f-df7cfe3ee0e4",
+   "execution_count": null,
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42bd4ce9-ca74-4163-8fa5-72960c2dfe15",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Defining the Curve\n",
@@ -38,21 +38,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "62acfbff-7335-4618-aeeb-375bc5f9388e",
+   "execution_count": null,
+   "id": "3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Projective Plane Curve with defining polynomial 16*x^4 + y^4 + 8*y^3*z + 16*x*y*z^2 + 4*x*z^3 over Rational Field with 2-adic valuation"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define the polynomial ring and valuation\n",
     "R.<x,y,z> = QQ[]\n",
@@ -68,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31bc589e-7344-4c12-96ba-b14b2dfa8025",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Computing the Semistable Model\n",
@@ -82,21 +71,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "d7953450-89f0-4803-88bf-be68636aa8e6",
+   "execution_count": null,
+   "id": "5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Plane Model of Projective Plane Curve with defining polynomial 16*x^4 + y^4 + 8*y^3*z + 16*x*y*z^2 + 4*x*z^3 over Rational Field with 2-adic valuation"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "X = Y.semistable_model()\n",
     "X"
@@ -104,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79dd0f39-15ff-45d2-9e13-7aa808f3d567",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Verification and Base Extension\n",
@@ -114,19 +92,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "ddb3e113-fa75-47b9-9666-a8e51cdbbbfa",
+   "execution_count": null,
+   "id": "7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Has semistable reduction: True\n",
-      "Base field extension: Number Field in piL with defining polynomial x^12 + 2*x^6 + 2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Has semistable reduction:\", X.has_semistable_reduction())\n",
     "print(\"Base field extension:\", X.base_ring())"
@@ -134,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9eea33b4-0163-48d2-9100-72f3ed51d8b6",
+   "id": "8",
    "metadata": {},
    "source": [
     "### The Special Fiber\n",
@@ -144,19 +113,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "0bf2f522-42cb-48ab-a5c0-caffc63c3dae",
+   "execution_count": null,
+   "id": "9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Special Fiber: Projective Plane Curve with defining polynomial x^4 + x^2*y^2 + y*z^3 over Finite Field of size 2\n",
-      "Is stable: True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "Xs = X.special_fiber()\n",
     "print(\"Special Fiber:\", Xs)\n",
@@ -166,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5323b5c-b36c-4e1b-baf8-d28fbb44fb90",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
### Summary
This PR fixes an issue where `notebooks/Example_Semistable_Model.ipynb` persistently showed as "modified" after merges, despite no manual changes.

### Changes
* **Added `.gitattributes`:** Explicitly configures the repository to use `nbstripout` filters for Jupyter Notebooks.
* **Renormalized Notebook:** Stripped metadata and output from `Example_Semistable_Model.ipynb` to match the clean filter state.

### Impact
This ensures that `git status` remains clean for all developers and prevents future metadata conflicts in the repository.