### PR TITLE
Renames the generator of the base field of special fiber.

### DIFF
--- a/semistable_model/curves/plane_curves_valued.py
+++ b/semistable_model/curves/plane_curves_valued.py
@@ -317,7 +317,14 @@ class PlaneModel(ProjectivePlaneCurve):
     E = identity_matrix(R.base_ring(), R.ngens())
     v_K = self.as_point_on_BTB().base_ring_valuation()
     v = LinearValuation(R, v_K, E, [0]*R.ngens())
-    return ProjectivePlaneCurve(v.reduction(self.defining_polynomial()))
+    f_wrong = v.reduction(self.defining_polynomial())
+    k_wrong = f_wrong.base_ring()
+    p = k_wrong.characteristic()
+    d = k_wrong.degree()
+    k_right = GF(p**d)
+    phi = k_wrong.an_embedding(k_right)
+    f_right = f_wrong.change_ring(phi)
+    return ProjectivePlaneCurve(f_right)
 
 
   def has_semistable_reduction(self):


### PR DESCRIPTION
The special fiber is a projective plane curve over the residue field of a valuation. Currently, the `residue_field()` method returns a finite field with a generator variable name (e.g. `u1`) that conflicts with internal variables in the Singular library `primdec.lib` when `is_stable()` is called. This PR resolves the resulting `TypeError` by explicitly instantiating the residue field as `GF(p^d)`, ensuring a standard generator name that avoids the name collision.