### PR TITLE
Fix cusp resolution

### DIFF
--- a/semistable_model/curves/approximate_factors.py
+++ b/semistable_model/curves/approximate_factors.py
@@ -84,7 +84,7 @@ def approximate_factorization(f, v_K, g0=None, assume_squarefree=False,
     
     INPUT:
 
-    - ``f`` -- a nonconstant polynomial over a number field `k`
+    - ``f`` -- a nonconstant polynomial over a number field `K`
     - ``v_K`` - a nontrivial discrete valuation on `K`
     - `g0` -- an approximate factor of `f`, or ``None``
     - `assume_squarefree` --  a boolean (default: ``False``)
@@ -112,6 +112,9 @@ def approximate_factorization(f, v_K, g0=None, assume_squarefree=False,
                                               assume_squarefree=True, 
                                               assume_irreducible=True)
         return ret
+    # make f integral and primitive
+    m = min(v_K(c) for c in f.coefficients())
+    f = v_K.element_with_valuation(-m)*f
     if g0 is None:
         v0 = GaussValuation(f.parent(), v_K)
         g0 = ApproximateFactor(f, v0)
@@ -123,6 +126,36 @@ def approximate_factorization(f, v_K, g0=None, assume_squarefree=False,
                                           assume_squarefree=True, 
                                           assume_irreducible=True)
     return ret
+
+
+def approximate_roots(f, v_K, positive_valuation=True):
+    r"""
+    Return approximate roots of an univariate polynomial.
+
+    INPUT:
+
+    - ``f`` -- a nonconstant polynomial over a number field `K`
+    - ``v_K`` -- a `p`-adic valuation on `K`
+    - ``positive_valuation`` -- boolean (default: ``True``); if set, 
+                                require `v_L(a) > 0` for all approximations
+
+    OUTPUT:
+
+    a list of instances of :class:`ApproximateRoot`.
+
+    The returned objects represent approximate roots `a in L` (for some finite
+    extension `(L,v_L)/(K,v_K)`) whose residual valuations can be made arbitrarily large
+    by repeated calls to :meth:`ApproximateRoot.improve_approximation`.
+
+    """
+    factors = approximate_factorization(f, v_K)
+    if positive_valuation:
+        return [ApproximateRoot(g) for g in factors if g.value() > 0]
+    else:
+        # the test g.value() >= 0 is superfluous because the current code
+        # only produces factors with this property; included for clarity 
+        # and because this may change in the future
+        return [ApproximateRoot(g) for g in factors if g.value()>=0]
 
 
 class ApproximateFactor(SageObject):
@@ -163,7 +196,7 @@ class ApproximateFactor(SageObject):
         self._equivalence_decomposition = F
 
     def __repr__(self):
-        return f"approximate factor of {self._polynomial()} of degree {self.degree()}"
+        return f"approximate factor of {self.polynomial()} of degree {self.degree()}"
     
     def base_valuation(self):
         return self._base_valuation
@@ -244,7 +277,8 @@ class ApproximatePrimeFactor(ApproximateFactor):
       
     """
     def __init__(self, f, v):
-        v_K = v._base_valuation
+        K = f.base_ring()
+        v_K = v.restriction(K)
         assert v.domain() == f.parent(), "the domain of v must be the parent of f"
         self._polynomial = f
         self._valuation = v
@@ -271,7 +305,7 @@ class ApproximatePrimeFactor(ApproximateFactor):
             self._compute_precision()
 
     def __repr__(self):
-        return f"approximate prime factor of {self._polynomial()} of degree {self.degree()}"
+        return f"approximate prime factor of {self.polynomial()} of degree {self.degree()}"
     
     def _compute_precision(self):
         r""" Compute and store the current precision of this approximate prime factor.
@@ -283,7 +317,7 @@ class ApproximatePrimeFactor(ApproximateFactor):
         self._precision = max((v_g(F[0]) - v_g(F[i]))/i for i in range(1, self.degree() + 1))
 
     def polynomial(self):
-        r""" Return the irreducible polynomial of which this is aan approximate prime factor.
+        r""" Return the irreducible polynomial of which this is an approximate prime factor.
         """
         return self._polynomial
     
@@ -362,6 +396,221 @@ class ApproximatePrimeFactor(ApproximateFactor):
             return self.valuation().phi()
         
 
+class ApproximateRoot(SageObject):
+    r"""
+    An object representing an *approximate root* of an univariate polynomial.
+
+    INPUT:
+
+    - ``g`` -- an instance of :class:`ApproximatePrimeFactor`, representing
+               an irreducible factor of a polynomial `f` over the completion
+               `\hat{K}` of its base field `K`
+    - ``name`` -- an alphanumerical string (default: "alpha")
+
+    OUTPUT:
+
+    an object representing the tautological root `a\in \hat{L}`, where 
+
+    .. MATH::
+
+        \hat{L} := \hat{K}[x]/(g)
+
+    Internally, an approximate root `a` is represented by 
+
+    - an approximate prime factor `g` of `f`
+    - a fixed approximation `g_0` of `g`.
+
+    The approximation `g_0` has the property that the stem field 
+
+    .. MATH::
+
+        L := K(a_0) = K[x]/(g_0)
+
+    of `g_0` is stable, after completion and up to isomorphism, for further 
+    approximations of `g`. By Krasner's Lemma this condition is satisfied 
+    for every sufficiently precise approximation `g_0`. 
+
+    The element `a_0\in L`, the tautological root of `g_0`, is then the
+    first approximation of the approximate root `a`. 
+
+    Calling :meth:`improve_approximation` computes and returns an improved 
+    approximation.
+
+    """
+    def __init__(self, g, name="alpha"):
+        self._is_exact = (g.precision() == Infinity)
+        self._g = g
+        f = g.polynomial()
+        self._f = f
+        self._df = f.derivative()
+        # 1. improve approximation until Hensel's lemma applies
+        self._force_hensel()
+        # 2. construct L
+        K = self.base_field()
+        g0 = self.prime_factor().approximate_factor()
+        L = K.extension(g0, name)
+        v_L = self.base_valuation().extension(L)
+        self._extension = L
+        self._extension_valuation = v_L
+        # 3. initialize first approximation
+        self._approximation = L.gen()
+        self._precision = g.precision()
+        # 4. construct limit valuation
+        # to do:
+        # self._init_limit_valuation()
+
+    def base_field(self):
+        r""" Return the base field of this approximate root.
+        """
+        return self.prime_factor().base_field()
+    
+    def base_valuation(self):
+        r""" Return the valuation of the base field of this approximate root.
+        """
+        return self.prime_factor().base_valuation()
+
+    def prime_factor(self):
+        r""" Return the strong prime factor of which ``self`` is a root. 
+        """
+        return self._g
+
+    def extension(self):
+        r"""Return the field extension in which this approximate root lives."""
+        return self._extension
+
+    def extension_valuation(self):
+        r"""Return the valuation on the extension field."""
+        return self._extension_valuation
+    
+    def polynomial_ring(self):
+        return self.polynomial().parent()
+    
+    def polynomial(self):
+        r""" Return the polynomial of which ``self`` is a root.
+        """
+        return self._f
+    
+    def derivative(self):
+        return self._df
+    
+    def value(self):
+        r""" Return the valuation of this root.
+        """
+        return self.prime_factor().value()
+
+    def approximation(self):
+        r"""Return the current approximation of this root."""
+        return self._approximation
+    
+    def precision(self):
+        r""" Return a lower bound for the precision of the current approximation.
+        
+        If `t` is return, then `v_L(a-a_0) >= t`, where `a_0` is the 
+        current approximation and `a` is the exact root. 
+        """
+        if self.is_exact():
+            return Infinity
+        # I need to check this later!
+        return  2**self._count*(self._m - 2*self._s) + self._s
+    
+    def is_exact(self):
+        r""" Return whether this approximate root is exact.
+        
+        """
+        return self._is_exact
+    
+    def value_of_poly(self, r):
+        r"""Return the valuation of a polynomial in this root.
+        
+        INPUT:
+
+        - ``r`` -- a univariate polynomial over the base field
+
+        OUTPUT:
+
+        the valuation `v_L(r(a))`, where `a\in \hat{L}` is the root
+        of `f` represented by ``self``.
+
+        """
+        try:
+            r = self.polynomial_ring()(r)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"r must be coercible into {self.polynomial_ring()} (got {r.parent()})")
+        return self._limit_valuation(r)
+
+    def improve_approximation(self):
+        r"""
+        Improve the current approximation.
+
+        OUTPUT:
+
+        The improved approximation of this root.
+
+        """
+        if self.is_exact():
+            # there is nothing to improve
+            return
+        # we can assume that the approximation can be improve using Hensel's Lemma, 
+        # i.e. Newton approximation
+        f = self.polynomial()
+        df = self.derivative()
+        a0 = self._approximation
+        t = self.precision()
+        a = a0 - f(a0)/df(a0)
+        # simplify a; we assume quadratic convergence
+        a = self.extension_valuation().simplify(a, 2*t+1)
+        self._approximation = a
+        self._count = self._count + 1
+        return a
+    
+    def _force_hensel(self):
+        r""" Improve the approximation of the prime factor `g` so that
+        approximations of the root can be improved using Hensel's Lemma.
+        
+        This guarantees that the stem field `\hat{L}=\hat{K}[x]/(g_0)`, 
+        where `g_0` is the current approximation, contains the root of `f`
+        represented by ``self``.
+        """
+        
+        if self.is_exact():
+            self._precision = Infinity
+            return
+        g = self.prime_factor()
+        g.improve_approximation()
+        f = self.polynomial()
+        df = self.derivative()
+        m = g.valuation()(f)
+        s = g.valuation()(df)
+        while m <= 2*s + 1:
+            g.improve_approximation()
+            m = g.valuation()(f)
+            s = g.valuation()(df)
+        self._count = 0
+        self._m = m
+        self._s = s
+    
+    def _init_limit_valuation(self):
+        r""" Construct the limit valuation corresponding to this approximate root,
+        i.e. the discrete valuation v on `K[x]` such that
+        
+        .. MATH::
+
+            v(r) = v_L(r(a)),
+
+        for all polynomials `r\in K[x]`, and where `a\in\hat{L}` is the exact root
+        represented by this approximate root. 
+        """
+        # in principal we can use LimitValuation(v, f), where v is the MacLane valuation
+        # corresponding to the approximate factor.
+        # the problem is that this only works if f is monic and integral
+        # which we can't assume. 
+        # We have to force this by scaling, i.e. replace f by
+        # f(pi_K^(-m)*x).monic(), v by the right valuation and then rescaling the result
+        raise NotImplementedError()
+
+
+
 # ---------------------------------------------------------------------------------------
 
 #     Tests
@@ -376,3 +625,15 @@ def test_precision(g):
         print(f"prec = {g.precision()}")
         print()
         g.improve_approximation()
+
+def test_approximate_roots(R, v_K, N=10, d = 12):
+    for _ in range(N):
+        f = R.random_element(d)
+        print()
+        print(f"f = {f}")
+        roots = approximate_roots(f, v_K)
+        for a in roots:
+            print(f"   a_0 = {a.approximation()}")
+            for _ in range(5):
+                a.improve_approximation()                
+            print(f"v_L(f(a_5)) = {a.extension_valuation()(f(a.approximation()))}")

--- a/semistable_model/curves/approximate_solutions.py
+++ b/semistable_model/curves/approximate_solutions.py
@@ -1,0 +1,405 @@
+# -*- coding: utf-8 -*-
+r"""
+Approximate solutions for zero-dimensional ideals
+=================================================
+
+Let `K` be a number field and `v_K` a `p`-adic valuation on `K`. Let
+
+.. MATH::
+
+    J = (F_1,\ldots,F_m) \subset K[x_1,\ldots,x_n]
+
+be an ideal of dimension zero. Then the system
+
+.. MATH::
+
+    F_1(x_1,\ldots,x_n)=\cdots=F_m(x_1,\ldots,x_n)=0
+
+has only finitely many solutions in an algebraic closure of `K`.
+
+We are interested in *approximate solutions* with respect to `v_K`. By this we
+mean a sequence
+
+.. MATH::
+
+    a^{(k)} = (a_1^{(k)},\ldots,a_n^{(k)}) \in L^n
+
+for a finite extension of valued fields `(L,v_L)/(K,v_K)` such that
+
+.. MATH::
+
+    v_L(F_i(a^{(k)})) \to \infty \quad (k\to\infty)
+
+for all generators `F_i` (equivalently, such that the residual valuations can
+be made arbitrarily large).
+
+In this module we currently restrict to *integral* approximate solutions, i.e.
+those with
+
+.. MATH::
+
+    v_L(a_i^{(k)}) \ge 0 \quad \text{for all } i,k,
+
+and optionally to *strictly positive* solutions with `v_L(a_i^{(k)}) > 0`.
+
+Algorithmic approach
+--------------------
+
+We attempt to bring the ideal `J` into **shape position** via restricted linear
+changes of coordinates of the form
+
+.. MATH::
+
+    x_n \leftarrow x_n + b_1 x_1 + \cdots + b_{n-1} x_{n-1},\qquad x_i \leftarrow x_i \ (i<n),
+
+with small integers `b_i`. We use lexicographic order with
+
+.. MATH::
+
+    x_1 > x_2 > \cdots > x_n,
+
+so that in strict shape position the reduced Groebner basis has the form
+
+.. MATH::
+
+    x_1 - r_1(x_n),\ \ldots,\ x_{n-1} - r_{n-1}(x_n),\ f(x_n).
+
+In that case, all solutions are parametrized by roots of `f(x_n)=0`, and the
+remaining coordinates are obtained by evaluation
+
+.. MATH::
+
+    x_i = r_i(x_n).
+
+We then use the existing MacLane-based univariate approximation machinery to
+produce approximate roots of `f` over suitable extensions `(L,v_L)/(K,v_K)`,
+and evaluate the `r_i` to obtain approximate solutions of the original system.
+
+NOTE:
+Since shape position is reached via a heuristic (partially probabilistic)
+coordinate change, the function may raise an error after a specified number of
+unsuccessful attempts.
+
+EXAMPLES::
+
+    sage: v2 = QQ.valuation(2)
+    sage: R.<x,y> = QQ[]
+    sage: J = R.ideal([x^2 + y^2 + 2, 2*x^2 + x*y + y])
+    sage: S = approximate_solutions(J, v2)
+    sage: len(S)
+    2
+    sage: s = S[0]
+    sage: s.extension()
+    ...
+    sage: s.approximation()
+    ...
+    sage: s.improve_approximation()
+    ...
+"""
+
+from sage.all import SageObject, ZZ
+
+
+def approximate_solutions(J, v_K, positive_valuation=True, one_solution=False,
+                          max_tries=8, bound=2, seed=1, try_list=None):
+    r"""
+    Return approximate solutions of a zero-dimensional system.
+
+    INPUT:
+
+    - ``J`` -- an ideal in a polynomial ring `K[x_1,...,x_n]` over a number field `K`;
+               it is assumed that we have lex term order with `x_1 > \ldots > x_n`
+    - ``v_K`` -- a `p`-adic valuation on `K`
+    - ``positive_valuation`` -- boolean (default: ``True``); if set, require `v_L(a_i) > 0`
+                                for all coordinates of the approximation
+    - ``one_solution`` -- boolean (default: ``False``); if set, return only the first
+                          solution found (or ``None`` if none is found)
+    - ``max_tries`` -- positive integer; number of coordinate changes attempted
+    - ``bound`` -- positive integer; random integers `b_i` are sampled from `[-bound, bound]`
+    - ``seed`` -- integer seed for deterministic pseudo-random tries
+    - ``try_list`` -- optional list of tuples `(b_1,...,b_{n-1})` tried before random tries
+
+    OUTPUT:
+
+    If ``one_solution`` is ``False``:
+        a list of instances of :class:`ApproximateSolution`.
+
+    If ``one_solution`` is ``True``:
+        a single instance of :class:`ApproximateSolution`, or ``None``.
+
+    The returned objects represent approximate solutions `a^(k) in L^n` (for some finite
+    extension `(L,v_L)/(K,v_K)`) whose residual valuations can be made arbitrarily large
+    by repeated calls to :meth:`ApproximateSolution.improve_approximation`.
+
+    Raises an error in any of the following cases:
+    
+    - ``dim(J) != 0`` 
+    - the term order id not `lex`
+    - if shape position is not reached after ``max_tries`` attempts.
+    """
+    if try_list is None:
+        try_list = []
+
+    _check_dim_zero(J)
+    _check_lex_order(J)
+
+    # Step 1: attempt shape position
+    J1, phi, f, rs = _put_in_shape_position(J, max_tries=max_tries, bound=bound,
+                                            seed=seed, try_list=try_list)
+
+    # Step 2: build one ApproximateSolution per "univariate branch" for f(x_n)=0
+    sols = []
+    for br in _branches_for_shape_polynomial(f, v_K):
+        sol = ApproximateSolution(J1, phi, f, rs, v_K, br,
+                                  positive_valuation=positive_valuation)
+        if sol.is_admissible():
+            if one_solution:
+                return sol
+            sols.append(sol)
+
+    if one_solution:
+        return None
+    return sols
+
+
+class ApproximateSolution(SageObject):
+    r"""
+    An object representing an *approximate solution* to a zero-dimensional system.
+
+    Internally, a solution is represented by a univariate approximation branch for the
+    shape polynomial `f(x_n)=0` over some finite extension `(L,v_L)/(K,v_K)`. The remaining
+    coordinates are obtained by evaluating `x_i = r_i(x_n)`.
+
+    Calling :meth:`improve_approximation` refines the approximation of `x_n`, and thereby
+    improves the residual valuations of the defining equations.
+    """
+
+    def __init__(self, J1, phi, f, rs, v_K, branch, positive_valuation=True):
+        self._J1 = J1
+        self._phi = phi
+        self._f = f
+        self._rs = rs
+        self._v_K = v_K
+        self._branch = branch
+        self._positive_valuation = positive_valuation
+
+        self._R = J1.ring()
+        self._xs = tuple(self._R.gens())
+        self._x_shape = self._xs[-1]
+
+        # Branch must provide (L,v_L) and a way to refine x_n
+        self._extension = _branch_field(branch)
+        self._extension_valuation = _branch_valuation(branch)
+
+        self._approximation = None
+        self._residual_min = None
+
+        # initialize first approximation
+        self.improve_approximation()
+
+    def extension(self):
+        r"""Return the field extension in which this approximate solution lives."""
+        return self._extension
+
+    def extension_valuation(self):
+        r"""Return the valuation on the extension field."""
+        return self._extension_valuation
+
+    def approximation(self):
+        r"""Return the current approximation vector `[a_1,...,a_n]`."""
+        return self._approximation
+
+    def residual_valuation(self):
+        r"""Return `min_i v_L(F_i(a))` for the chosen generators at the current approximation."""
+        return self._residual_min
+
+    def is_admissible(self):
+        r"""
+        Return True if the current approximation satisfies the requested valuation constraint
+        on the coordinates (integral or strictly positive).
+        """
+        vL = self._extension_valuation
+        if vL is None or self._approximation is None:
+            return False
+
+        if self._positive_valuation:
+            return all(vL(ai) > 0 for ai in self._approximation)
+        else:
+            return all(vL(ai) >= 0 for ai in self._approximation)
+
+    def improve_approximation(self):
+        r"""
+        Improve the current approximation.
+
+        OUTPUT:
+
+        The improved approximation vector `[a_1,...,a_n]`.
+
+        This method refines the underlying univariate approximation for `x_n`, evaluates
+        `x_i=r_i(x_n)` for `i<n`, and updates the cached residual valuation.
+        """
+        x_shape = _branch_next_root_approx(self._branch)
+        vec = []
+        for r in self._rs:
+            vec.append(r(x_shape))
+        vec.append(x_shape)
+
+        self._approximation = vec
+        self._residual_min = _min_residual_valuation(self._J1, self._xs, vec,
+                                                     self._extension_valuation)
+        return self._approximation
+
+
+# --------------------------------------------------------------------
+# Helper functions (technical; keep at end of file)
+# --------------------------------------------------------------------
+
+def _check_dim_zero(J):
+    d = J.dimension()
+    if d != 0:
+        raise ValueError("Expected dim(J)=0, got dim(J)=%s." % d)
+
+def _check_lex_order(J):
+    R = J.ring()
+    if R.term_order().name() != 'lex':
+        raise ValueError(
+            "approximate_solutions requires lexicographic term order. "
+            f"Got term order: {R.term_order()}."
+        )
+
+def _put_in_shape_position(J, max_tries=8, bound=2, seed=1, try_list=None):
+    r"""
+    Try restricted transforms x_n <- x_n + sum_{i<n} b_i x_i until strict shape form holds.
+
+    OUTPUT:
+        (J1, phi, f, rs) as in the module documentation.
+
+    Raises NotImplementedError if unsuccessful after max_tries.
+    """
+    if try_list is None:
+        try_list = []
+
+    R = J.ring()
+    xs = tuple(R.gens())
+    n = len(xs)
+
+    tries = [tuple(0 for _ in range(n - 1))]
+    for t in try_list:
+        tries.append(tuple(int(x) for x in t))
+
+    gen = _random_shape_transforms(n, bound=bound, seed=seed)
+    while len(tries) < max_tries:
+        tries.append(next(gen))
+
+    last_err = None
+    for bs in tries:
+        J1, phi = _apply_shape_transform_to_ideal(J, xs, bs)
+        try:
+            G = J1.groebner_basis()
+            f, rs = _strict_shape_data_from_groebner(G, xs)
+            return J1, phi, f, rs
+        except Exception as e:
+            last_err = e
+
+    raise NotImplementedError(
+        "Failed to put ideal into strict shape position after %s tries. Last error: %s"
+        % (max_tries, last_err)
+    )
+
+
+def _strict_shape_data_from_groebner(G, xs):
+    n = len(xs)
+    x_shape = xs[-1]
+
+    if len(G) != n:
+        raise ValueError("Expected Groebner basis of length %s, got %s." % (n, len(G)))
+
+    f = G[-1]
+    if not _is_univariate_in(f, x_shape):
+        raise ValueError("Not in shape position: last Groebner element not univariate in x_n.")
+
+    r_map = {}
+    for i in range(n-1):
+        xi = xs[i]
+        found = None
+        for p in G:
+            if p.degree(xi) != 1:
+                continue
+            if p.coefficient({xi: 1}) != 1:
+                continue
+            # must not involve xj (j<n) other than xi
+            bad = False
+            for xj in xs[:-1]:
+                if xj != xi and (xj in p.variables()):
+                    bad = True
+                    break
+            if bad:
+                continue
+            r = -p.subs({xi: 0})
+            if not _is_univariate_in(r, x_shape):
+                continue
+            found = r
+            break
+        if found is None:
+            raise ValueError("Missing equation x_%s - r(x_n)." % (i+1))
+        r_map[i] = found
+
+    rs = [r_map[i] for i in range(n-1)]
+    return f, rs
+
+
+def _is_univariate_in(p, var):
+    vars_ = p.variables()
+    return vars_ == () or vars_ == (var,)
+
+def _apply_shape_transform_to_ideal(J, xs, bs):
+    R = J.ring()
+    x_shape = xs[-1]
+    new_x_shape = x_shape + sum(ZZ(bs[i]) * xs[i] for i in range(len(xs)-1))
+    phi = R.hom(list(xs[:-1]) + [new_x_shape])
+    return phi(J), phi
+
+def _random_shape_transforms(n, bound, seed):
+    state = seed & 0xFFFFFFFF
+    while True:
+        bs = []
+        for _ in range(n - 1):
+            state = (1103515245 * state + 12345) & 0x7FFFFFFF
+            b = int(state % (2 * bound + 1)) - bound
+            bs.append(b)
+        yield tuple(bs)
+
+
+def _branches_for_shape_polynomial(f, v_K):
+    r"""
+    Return a list of branch objects describing approximate root clusters of f with v(root) >= 0
+    (or >0, depending on your univariate machinery).
+
+    This is the only place that must be connected to your MacLane-based code.
+    """
+    # TODO: replace by your actual API from approximate_factors.py
+    from semistable_model.curves.approximate_factors import approximate_factors
+    return list(approximate_factors(f, v_K))
+
+
+def _branch_field(branch):
+    return getattr(branch, "field", None)
+
+
+def _branch_valuation(branch):
+    return getattr(branch, "valuation", None)
+
+
+def _branch_next_root_approx(branch):
+    if hasattr(branch, "next_root_approx"):
+        return branch.next_root_approx()
+    if hasattr(branch, "__next__"):
+        return next(branch)
+    raise NotImplementedError("Branch object does not provide a refinement method for x_n.")
+
+
+def _min_residual_valuation(J1, xs, vec, vL):
+    subs = {xs[i]: vec[i] for i in range(len(vec))}
+    # default: track residual on Groebner basis generators; you can change to J1.gens()
+    vals = [vL(F.subs(subs)) for F in J1.groebner_basis()]
+    return min(vals) if vals else None

--- a/semistable_model/curves/cusp_resolution.py
+++ b/semistable_model/curves/cusp_resolution.py
@@ -75,7 +75,7 @@ def resolve_cusp(F, v_K, only_tail_type=False, return_J=False):
 
     EXAMPLES:
 
-    The following example gives an error:
+    The following example caused problems before, but is now fixed:
 
         sage: R.<x,y,z> = QQ[]
         sage: F = -16*x^4 - 15*x^3*y - 12*x^2*y^2 - 5*x*y^3 + 15*x^2*z^2 + 12*x*y*z^2 - 4*y^2*z^2 + 8*z^4
@@ -89,11 +89,12 @@ def resolve_cusp(F, v_K, only_tail_type=False, return_J=False):
         sage: T = C.move_to_e0_x2()
         sage: M = T.map_coefficients(v_L.lift, L)
         sage: cusp_model = XX.apply_matrix(M)
-        sage: resolve_cusp(cusp_model.defining_polynomial(), v_L)
-        ---------------------------------------------------------------------------
-        NotImplementedError                       Traceback (most recent call last)
-        ...
-        NotImplementedError: Expected G[1] to be linear in beta (beta - r(alpha)).
+        sage: v_L, _, Fb = resolve_cusp(cusp_model.defining_polynomial(), v_L) # long time!
+        sage: Fb
+        y^3 + x^2*z + x*z^2
+
+        sage: v_L.domain()
+        Number Field in alpha with defining polynomial a^8 - 129920/13*a^7 ... over its base field
 
     """
 

--- a/semistable_model/curves/cusp_resolution.py
+++ b/semistable_model/curves/cusp_resolution.py
@@ -28,14 +28,17 @@ whose special fiber consists of a semistable plane cubic in Weierstrass normal f
 plus the line at infinity. Thus this cubic is the one-tail of the semistable model
 corresponding to the cusp.  
 
+TODO (benchmark): experiment with different variable orders in R to compare performance.
+
+
 """
 
 
 from sage.all import QQ, NumberField, PolynomialRing, matrix, Infinity, randint, Curve, SR
-from semistable_model.curves.approximate_factors import approximate_factorization
+from semistable_model.curves.approximate_solutions import approximate_solutions
 
 
-def resolve_cusp(F, v_K):
+def resolve_cusp(F, v_K, return_J=False):
     r""" Return a base change matrix resolving the cusp.
 
     INPUT:
@@ -119,51 +122,18 @@ def resolve_cusp(F, v_K):
     # we want to find an approximate solution alpha, beta, gamma for
     # A=B=C=0, with valuations at least v_a,v_b,v_c
     J = R.ideal([A, B, C])
-    G = J.groebner_basis()
+    # this is for debugging only:
+    if return_J:
+        return J
 
-    f, _, _ = assert_groebner_expected_order(G, a, b, c)
-    f = f.univariate_polynomial()
-    # proceed with root finding on f and set beta=r(alpha), gamma=s(alpha)
-
-    # old code
-    # assert len(G) == 3, "Unexpected Groebner basis length."
-    # f = G[2].univariate_polynomial()
-
-    f_factors = approximate_factorization(f, v_K)
-    # print(f"f_factors = {f_factors}")
-    # f is a univariate equation for alpha
-    # we have to identify the correct factor of f, whose root alpha
-    # leads to a solution with alpha, beta, gamma of positive valuation
-
-    # beta and gamma are polynomials in alpha; we find the minimal valuation
-    # m of the coefficients of these polynomials
-    m1 = min(v_K(c) for c in G[0].coefficients())
-    m2 = min(v_K(c) for c in G[1].coefficients())
-    m = min(m1, m2)
-    # print(m1, m2, m)
-    
-    # we have to compute alpha with a precision strictly greater than 
-    # max(0, -m); because then we can already guarantee whether the valuation
-    # of beta and gamma are positive
-    
-    for g in f_factors:
-        # print(f"We try the factor g = {g.approximate_factor()} of degree {g.degree()}")
-        # print()
-        prec = max(0, -m) + 2
-        # print(f"precision = {prec}")
-        v_L, alpha, beta, gamma = _solve1(G, g, v_K, prec)
-        # print(f"solution over {v_L.domain()} with precision {prec}")
-        V = [v_L(a) for a in [alpha, beta, gamma]]
-        # print(f"V = {V}")
-        if all(v > 0 for v in V):
-            # we have found the correct factor g
-            break
-    else:
-        # no factor was found
-        raise ValueError("no solution was found!")
-    
-    # now g is the correct factor of f, but its current precision may not
-    # be sufficient
+    # we find *one* solution to A=B=C=0 in the maximal ideal of O_K
+    s = approximate_solutions(J, v_K, positive_valuation=True, one_solution=True)
+    if s is None:
+        raise ValueError("No solution found! this shouldn't have happend..")
+     
+    L = s.extension()
+    v_L = s.extension_valuation() 
+    gamma, beta, alpha = s.approximation()
     z, x, y = F.variables()
     while True:
         F1 = F(z, alpha*z + x, beta*z + gamma*x + y)
@@ -178,18 +148,22 @@ def resolve_cusp(F, v_K):
         if all([V[i, j]/(6-2*i-3*j) > t for i, j in tests]):
             break
         else:
-            prec += 5
-            v_L, alpha, beta, gamma = _solve1(G, g, v_K, prec)
+            gamma, beta, alpha = s.improve_approximation()
 
     # we now have to extend L such that it contains an element Pi with
     # valuation t; then the reduction of F_2:=F_1(Pi^2*x,Pi^3*y,z)
-    
+    L = v_L.domain()
     if not t in v_L.value_group():
         e = (t*v_L.value_group().denominator()).denominator()
-        # we have to replace L by an extension with ramification index e,
-        # and compute alpha, beta, gamma again
-        v_L, alpha, beta, gamma = _solve1(G, g, v_K, prec, E=e)
-    L = v_L.domain()
+        # we have to replace L by an extension with ramification index e
+        S = PolynomialRing(L, "pi")
+        pi = S.gen()
+        L = L.extension(pi**e - v_L.uniformizer(), "pi_e")
+        v_L = v_L.extension(L)
+        alpha = L(alpha)
+        beta = L(beta)
+        gamma = L(gamma)
+    
     Pi = v_L.element_with_valuation(t)
     F1 = F(z, alpha*z + x, beta*z + gamma*x + y)
     F2 = F1(z, Pi**2*x, Pi**3*y)/Pi**6
@@ -198,29 +172,6 @@ def resolve_cusp(F, v_K):
     T = matrix(L, 3, 3, [1, alpha, beta, 0, Pi**2, Pi**2*gamma, 0, 0, Pi**3])
     return v_L, T, Fb
     
-
-def _solve1(G, g, v_K, prec, E=1):
-    r""" Return v_L, alpha, beta, gamma
-
-    This is a helper function for `resolve_cusp`.
-    
-    """
-    c, b, _ = G[0].parent().gens()
-    K = v_K.domain()
-    if E == 1:
-        L = K.extension(g.approximate_factor(prec), "alpha")
-        v_L = v_K.extension(L)
-        alpha = L.gen()
-    else:
-        S = PolynomialRing(K, "pi")
-        pi = S.gen()
-        L = NumberField([g.approximate_factor(prec), pi**E-v_K.p()], ["alpha", "pi"])
-        alpha, pi, *_ = L.gens()
-        v_L = v_K.extension(L)
-    beta = v_L.simplify(-G[1](c, b, alpha).univariate_polynomial()[0], prec)
-    gamma = v_L.simplify(-G[0](c, b, alpha).univariate_polynomial()[0], prec)
-    return v_L, alpha, beta, gamma 
-        
 
 def _valuation_matrix(F1, d, v_L):
     r"""
@@ -237,57 +188,6 @@ def _valuation_matrix(F1, d, v_L):
                     t = QQ(s)
     return V, t
 
-
-def _is_univariate_in(p, var):
-    # True iff p involves no variables other than var
-    vars_ = p.variables()
-    return vars_ == () or vars_ == (var,)
-
-
-def assert_groebner_expected_order(G, alpha, beta, gamma):
-    """
-    Assert that the Groebner basis G is exactly in the expected triangular form
-        [gamma - s(alpha), beta - r(alpha), f(alpha)]
-    (with respect to lex(gamma, beta, alpha)), and normalized so the leading
-    coefficients of gamma and beta are 1.
-
-    Raises NotImplementedError if not, otherwise returns (f, r, s).
-    """
-    if len(G) != 3:
-        raise NotImplementedError(f"Expected Groebner basis of length 3, got {len(G)}.")
-
-    p_gamma, p_beta, p_alpha = G[0], G[1], G[2]
-
-    # --- check G[2] = f(alpha)
-    if not _is_univariate_in(p_alpha, alpha):
-        raise NotImplementedError("Expected G[2] to be univariate f(alpha).")
-
-    # --- check G[1] = beta - r(alpha)
-    if gamma in p_beta.variables():
-        raise NotImplementedError("Expected G[1] to involve only alpha,beta (no gamma).")
-    if p_beta.degree(beta) != 1:
-        raise NotImplementedError("Expected G[1] to be linear in beta (beta - r(alpha)).")
-    if p_beta.coefficient({beta: 1}) != 1:
-        raise NotImplementedError("Expected G[1] to be monic in beta (leading coeff 1).")
-    r = -p_beta.subs({beta: 0})
-    if not _is_univariate_in(r, alpha):
-        raise NotImplementedError("Expected r(alpha) to be univariate in alpha.")
-
-    # --- check G[0] = gamma - s(alpha)
-    if p_gamma.degree(gamma) != 1:
-        raise NotImplementedError("Expected G[0] to be linear in gamma (gamma - s(alpha)).")
-    if p_gamma.coefficient({gamma: 1}) != 1:
-        raise NotImplementedError("Expected G[0] to be monic in gamma (leading coeff 1).")
-    s = -p_gamma.subs({gamma: 0})
-    if not _is_univariate_in(s, alpha):
-        raise NotImplementedError("Expected s(alpha) to be univariate in alpha.")
-    # (Strictly enforces "gamma - s(alpha)" i.e. no beta-dependence at all.)
-    if beta in p_gamma.variables():
-        raise NotImplementedError("Expected G[0] not to involve beta (gamma - s(alpha)).")
-
-    f = p_alpha  # already univariate
-
-    return f, r, s
 
 # ------------------------------------------------------------------------------------------------------
 

--- a/semistable_model/curves/cusp_resolution.py
+++ b/semistable_model/curves/cusp_resolution.py
@@ -28,17 +28,21 @@ whose special fiber consists of a semistable plane cubic in Weierstrass normal f
 plus the line at infinity. Thus this cubic is the one-tail of the semistable model
 corresponding to the cusp.  
 
-TODO (benchmark): experiment with different variable orders in R to compare performance.
+TODO: 
+
+- experiment with different variable orders in R to compare performance.
+- add flag in :func:`resolve_cusp` that allows computing the tail type without
+  computing the tail itself; this will be much faster.
 
 
 """
 
 
-from sage.all import QQ, NumberField, PolynomialRing, matrix, Infinity, randint, Curve, SR
+from sage.all import QQ, PolynomialRing, matrix, Infinity, randint, Curve, SR
 from semistable_model.curves.approximate_solutions import approximate_solutions
 
 
-def resolve_cusp(F, v_K, return_J=False):
+def resolve_cusp(F, v_K, only_tail_type=False, return_J=False):
     r""" Return a base change matrix resolving the cusp.
 
     INPUT:
@@ -54,10 +58,20 @@ def resolve_cusp(F, v_K, return_J=False):
 
     OUTPUT:
 
-    a tripel `(v_L, T, \bar{F})`, where `v_L` is an extension of `v_K` to a finite field
-    extension `L/K`, `T` is an upper triangular`(3,3)`-matrix over `L`,
+    a tripel `(v_L, T, \bar{F})`, where `v_L` is an extension of `v_K` to a finite 
+    field extension `L/K`, `T` is an upper triangular`(3,3)`-matrix over `L`,
     representing the base change to the plane model resolving the cusp `P`, and
     `\bar{F}` is a semistable cubic, the resulting one-tail.
+
+    FLAGS:
+
+    - if ``only_tail_type`` is ``True``, the function returns either "e" or "m",
+      depending on whether the exceptional divisor of the blowup is smooth
+      (elliptic tail, "e") or not (pigtail, "m")
+    - if ``return_J`` is ``True`` the function returns the ideal `J` of the 
+      polynomial ring `K[c,b,a]` corresponding to the system of equations
+      that needs to be solved by the resolution algorithm. This is for 
+      debugging purposes only, and should be removed at some point
 
     EXAMPLES:
 
@@ -80,7 +94,11 @@ def resolve_cusp(F, v_K, return_J=False):
         NotImplementedError                       Traceback (most recent call last)
         ...
         NotImplementedError: Expected G[1] to be linear in beta (beta - r(alpha)).
+
     """
+
+    if only_tail_type:
+        raise NotImplementedError("the `only tail type´ option is not yet implemented.")
     # check validity of the input
     assert v_K.is_discrete_valuation()
     K = v_K.domain()


### PR DESCRIPTION
Implement approximate_solutions via shape position
    and univariate approximation
    
    Add a robust approximation engine for zero-dimensional
    radical ideals using shape position and MacLane-based
    univariate ApproximateRoot machinery. The algorithm
    detects shape position via restricted coordinate changes,
    computes approximate roots of the shape polynomial, maps
    solutions back to the original coordinates, and refines
    them to arbitrarily high residual valuation.
    
    This fixes the cusp resolution bug caused by missing
    approximate solutions in nontrivial shape situations.
    The implementation explicitly assumes radical ideals
    and lex order, and correctly handles admissibility
    using limit valuations.
